### PR TITLE
Add app-aware mapping resolution for diagnostics and navigation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
-    permissions: 
+    permissions:
       checks: write
       issues: read
       pull-requests: write
@@ -25,7 +25,7 @@ jobs:
   # Format PR
   format_check:
     name: Checks Source Code Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5

--- a/src/main/java/ortus/boxlang/lsp/LanguageServer.java
+++ b/src/main/java/ortus/boxlang/lsp/LanguageServer.java
@@ -73,7 +73,9 @@ public class LanguageServer implements org.eclipse.lsp4j.services.LanguageServer
 			// TODO add an initialize method to ProjectContextProvider to pass in workspace folders
 			// and other client capabilities as needed
 			// as well as enforce the proper order of operations
-			ProjectContextProvider.getInstance().setWorkspaceFolders( params.getWorkspaceFolders() );
+			ProjectContextProvider provider = ProjectContextProvider.getInstance();
+			provider.setWorkspaceFolders( params.getWorkspaceFolders() );
+			provider.setAppContextFromInitializationOptions( params.getInitializationOptions() );
 
 			// this needs to come before parseWorkspace so that we can watch for changes to the lsp config file
 			if ( params.getCapabilities() != null

--- a/src/main/java/ortus/boxlang/lsp/workspace/ClassReferenceResolver.java
+++ b/src/main/java/ortus/boxlang/lsp/workspace/ClassReferenceResolver.java
@@ -1,0 +1,194 @@
+package ortus.boxlang.lsp.workspace;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+import ortus.boxlang.lsp.workspace.index.IndexedClass;
+import ortus.boxlang.lsp.workspace.index.ProjectIndex;
+
+/**
+ * Shared resolver for class/interface references used by diagnostics and navigation.
+ */
+public class ClassReferenceResolver {
+
+	private static final List<String>		CLASS_EXTENSIONS	= List.of( ".bx", ".cfc", ".bxs", ".cfm", ".bxm" );
+
+	private final ProjectContextProvider	provider;
+
+	public ClassReferenceResolver( ProjectContextProvider provider ) {
+		this.provider = provider;
+	}
+
+	public Optional<IndexedClass> resolveClass( String classReference, URI contextDocUri ) {
+		String cleanedReference = cleanClassReference( classReference );
+		if ( cleanedReference == null ) {
+			return Optional.empty();
+		}
+
+		ProjectIndex			index	= provider.getIndex();
+
+		// 1) Existing index/classpath resolution.
+		Optional<IndexedClass>	found	= index.findClassWithContext( cleanedReference, contextDocUri );
+		if ( found.isPresent() ) {
+			return found;
+		}
+
+		String simpleName = toSimpleClassName( cleanedReference );
+		if ( !simpleName.equalsIgnoreCase( cleanedReference ) ) {
+			found = index.findClassWithContext( simpleName, contextDocUri );
+			if ( found.isPresent() ) {
+				return found;
+			}
+		}
+
+		// 2) Mapping-aware resolution and lazy indexing.
+		Optional<Path> mappedClassPath = resolveMappedClassPath( cleanedReference );
+		if ( mappedClassPath.isEmpty() ) {
+			return Optional.empty();
+		}
+
+		Path	mappedPath	= mappedClassPath.get().toAbsolutePath().normalize();
+		URI		mappedUri	= mappedPath.toUri();
+		if ( index.needsReindexing( mappedUri ) ) {
+			index.indexFile( mappedUri );
+		}
+
+		// Resolve indexed class by file URI first.
+		Optional<IndexedClass> byFile = index.getAllClasses().stream()
+		    .filter( c -> c.fileUri() != null && c.fileUri().equals( mappedUri.toString() ) )
+		    .findFirst();
+		if ( byFile.isPresent() ) {
+			return byFile;
+		}
+
+		// Fall back to name-based lookups after indexing.
+		found = index.findClassWithContext( simpleName, contextDocUri );
+		if ( found.isPresent() ) {
+			return found;
+		}
+
+		return index.findClassWithContext( cleanedReference, contextDocUri );
+	}
+
+	public List<Location> resolveLocation( String classReference, URI contextDocUri ) {
+		String					cleanedReference	= cleanClassReference( classReference );
+		Optional<IndexedClass>	resolved			= resolveClass( cleanedReference, contextDocUri );
+		if ( resolved.isPresent() ) {
+			IndexedClass indexedClass = resolved.get();
+			if ( indexedClass.fileUri() != null ) {
+				Location location = new Location();
+				location.setUri( indexedClass.fileUri() );
+				location.setRange( indexedClass.location() != null ? indexedClass.location() : fileStartRange() );
+				return List.of( location );
+			}
+		}
+
+		// Fallback: if mapped file exists but indexing failed, still allow navigation to file start.
+		Optional<Path> mappedPath = resolveMappedClassPath( classReference );
+		if ( mappedPath.isPresent() ) {
+			Location location = new Location();
+			location.setUri( mappedPath.get().toAbsolutePath().normalize().toUri().toString() );
+			location.setRange( fileStartRange() );
+			return List.of( location );
+		}
+
+		// Joint client/server fallback: return a path-like URI based on the class reference.
+		// Mapping-aware clients can expand this with their local app context mappings.
+		if ( looksLikeMappedReference( cleanedReference ) ) {
+			Location location = new Location();
+			location.setUri( toUnresolvedReferencePathUri( cleanedReference ) );
+			location.setRange( fileStartRange() );
+			return List.of( location );
+		}
+
+		return new ArrayList<>();
+	}
+
+	private Range fileStartRange() {
+		return new Range( new Position( 0, 0 ), new Position( 0, 0 ) );
+	}
+
+	public Optional<Path> resolveMappedClassPath( String classReference ) {
+		String cleanedReference = cleanClassReference( classReference );
+		if ( cleanedReference == null ) {
+			return Optional.empty();
+		}
+
+		int firstDot = cleanedReference.indexOf( '.' );
+		if ( firstDot <= 0 || firstDot == cleanedReference.length() - 1 ) {
+			return Optional.empty();
+		}
+
+		String				alias		= canonicalizeAlias( cleanedReference.substring( 0, firstDot ) );
+		Map<String, Path>	mappings	= provider.getMappings();
+		Path				mappingRoot	= mappings.get( alias );
+		if ( mappingRoot == null ) {
+			return Optional.empty();
+		}
+
+		String remainder = cleanedReference.substring( firstDot + 1 ).replace( '.', '/' );
+		for ( String extension : CLASS_EXTENSIONS ) {
+			Path candidate = mappingRoot.resolve( remainder + extension ).toAbsolutePath().normalize();
+			if ( Files.isRegularFile( candidate ) ) {
+				return Optional.of( candidate );
+			}
+		}
+		return Optional.empty();
+	}
+
+	private String cleanClassReference( String classReference ) {
+		if ( classReference == null ) {
+			return null;
+		}
+		String cleaned = classReference.trim();
+		if ( cleaned.isEmpty() ) {
+			return null;
+		}
+		cleaned = cleaned.replace( "\"", "" ).replace( "'", "" ).trim();
+		return cleaned.isEmpty() ? null : cleaned;
+	}
+
+	private String toSimpleClassName( String classReference ) {
+		int lastDot = classReference.lastIndexOf( '.' );
+		return lastDot >= 0 && lastDot < classReference.length() - 1
+		    ? classReference.substring( lastDot + 1 )
+		    : classReference;
+	}
+
+	private String canonicalizeAlias( String rawAlias ) {
+		if ( rawAlias == null || rawAlias.isBlank() ) {
+			return "";
+		}
+		String alias = rawAlias.trim().replace( '\\', '/' );
+		while ( alias.startsWith( "/" ) ) {
+			alias = alias.substring( 1 );
+		}
+		while ( alias.endsWith( "/" ) ) {
+			alias = alias.substring( 0, alias.length() - 1 );
+		}
+		return alias.toLowerCase( Locale.ROOT );
+	}
+
+	private boolean looksLikeMappedReference( String classReference ) {
+		if ( classReference == null || classReference.isBlank() || !classReference.contains( "." ) ) {
+			return false;
+		}
+		String lower = classReference.toLowerCase( Locale.ROOT );
+		return !lower.startsWith( "java." );
+	}
+
+	private String toUnresolvedReferencePathUri( String classReference ) {
+		String normalizedPath = "/" + classReference.replace( '.', '/' );
+		return Path.of( normalizedPath ).toUri().toString();
+	}
+}

--- a/src/main/java/ortus/boxlang/lsp/workspace/ProjectAppContext.java
+++ b/src/main/java/ortus/boxlang/lsp/workspace/ProjectAppContext.java
@@ -1,0 +1,271 @@
+package ortus.boxlang.lsp.workspace;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * App-aware context sent by LSP clients during initialize.
+ */
+public record ProjectAppContext(
+    Path rootPath,
+    Map<String, Path> mappings,
+    List<Path> moduleDirs,
+    String contextHash ) {
+
+	private static final String DEFAULT_HASH = "default";
+	private static final Pattern MODULE_MAPPING_PATTERN = Pattern.compile(
+	    "(?is)this\\.(?:mapping|cfmapping)\\s*=\\s*(['\"])([^'\"]+)\\1"
+	);
+
+	public ProjectAppContext {
+		rootPath	= normalizePath( rootPath );
+		mappings	= Map.copyOf( mappings );
+		moduleDirs	= List.copyOf( moduleDirs );
+		contextHash	= contextHash == null || contextHash.isBlank()
+		    ? computeFallbackHash( rootPath, mappings, moduleDirs )
+		    : contextHash;
+	}
+
+	public static ProjectAppContext empty() {
+		return new ProjectAppContext(
+		    null,
+		    Map.of(),
+		    List.of(),
+		    DEFAULT_HASH
+		);
+	}
+
+	@SuppressWarnings( "unchecked" )
+	public static ProjectAppContext fromInitializationOptions( Object initializationOptions, Path workspaceRoot ) {
+		Map<?, ?> rootOptions = asMap( initializationOptions );
+		if ( rootOptions == null ) {
+			return emptyWithRoot( workspaceRoot );
+		}
+
+		Map<?, ?> boxlang = asMap( rootOptions.get( "boxlang" ) );
+		if ( boxlang == null ) {
+			return emptyWithRoot( workspaceRoot );
+		}
+		Map<?, ?> appContext = asMap( boxlang.get( "appContext" ) );
+		if ( appContext == null ) {
+			return emptyWithRoot( workspaceRoot );
+		}
+
+		Path rootPath = toPath( appContext.get( "rootPath" ), workspaceRoot, workspaceRoot );
+		if ( rootPath == null ) {
+			rootPath = normalizePath( workspaceRoot );
+		}
+		if ( rootPath == null ) {
+			rootPath = Paths.get( "." ).toAbsolutePath().normalize();
+		}
+
+		Map<String, Path>	mappings	= parseMappings( appContext.get( "mappings" ), rootPath );
+		List<Path>			moduleDirs	= parseModuleDirs( appContext.get( "moduleDirs" ), rootPath );
+		String				contextHash	= asString( appContext.get( "contextHash" ) );
+		mergeModuleDerivedMappings( mappings, moduleDirs );
+
+		return new ProjectAppContext( rootPath, mappings, moduleDirs, contextHash );
+	}
+
+	private static ProjectAppContext emptyWithRoot( Path workspaceRoot ) {
+		Path root = workspaceRoot != null
+		    ? normalizePath( workspaceRoot )
+		    : Paths.get( "." ).toAbsolutePath().normalize();
+		return new ProjectAppContext( root, Map.of(), List.of(), DEFAULT_HASH );
+	}
+
+	@SuppressWarnings( "unchecked" )
+	private static Map<?, ?> asMap( Object value ) {
+		value = normalizeJsonLike( value );
+		return value instanceof Map<?, ?> map ? map : null;
+	}
+
+	@SuppressWarnings( "unchecked" )
+	private static List<?> asList( Object value ) {
+		value = normalizeJsonLike( value );
+		return value instanceof List<?> list ? list : null;
+	}
+
+	private static Object normalizeJsonLike( Object value ) {
+		if ( value == null ) {
+			return null;
+		}
+		if ( value instanceof JsonNull ) {
+			return null;
+		}
+		if ( value instanceof JsonObject jsonObject ) {
+			Map<String, Object> converted = new LinkedHashMap<>();
+			for ( Map.Entry<String, JsonElement> entry : jsonObject.entrySet() ) {
+				converted.put( entry.getKey(), normalizeJsonLike( entry.getValue() ) );
+			}
+			return converted;
+		}
+		if ( value instanceof JsonArray jsonArray ) {
+			List<Object> converted = new ArrayList<>();
+			for ( JsonElement element : jsonArray ) {
+				converted.add( normalizeJsonLike( element ) );
+			}
+			return converted;
+		}
+		if ( value instanceof JsonPrimitive primitive ) {
+			if ( primitive.isBoolean() ) {
+				return primitive.getAsBoolean();
+			}
+			if ( primitive.isNumber() ) {
+				return primitive.getAsString();
+			}
+			return primitive.getAsString();
+		}
+		if ( value instanceof JsonElement element ) {
+			return normalizeJsonLike( element.deepCopy() );
+		}
+		return value;
+	}
+
+	private static Map<String, Path> parseMappings( Object rawMappings, Path rootPath ) {
+		Map<?, ?>			source	= asMap( rawMappings );
+		Map<String, Path>	parsed	= new LinkedHashMap<>();
+		if ( source == null || source.isEmpty() ) {
+			return parsed;
+		}
+		for ( Map.Entry<?, ?> entry : source.entrySet() ) {
+			String alias = canonicalizeAlias( asString( entry.getKey() ) );
+			if ( alias.isEmpty() ) {
+				continue;
+			}
+			Path path = toPath( entry.getValue(), rootPath, rootPath );
+			if ( path == null ) {
+				continue;
+			}
+			parsed.put( alias, path );
+		}
+		return parsed;
+	}
+
+	private static List<Path> parseModuleDirs( Object rawModuleDirs, Path rootPath ) {
+		List<?> moduleDirValues = asList( rawModuleDirs );
+		if ( moduleDirValues == null || moduleDirValues.isEmpty() ) {
+			return List.of();
+		}
+		List<Path> parsed = new ArrayList<>();
+		for ( Object value : moduleDirValues ) {
+			Path path = toPath( value, rootPath, rootPath );
+			if ( path != null ) {
+				parsed.add( path );
+			}
+		}
+		return parsed.stream().distinct().collect( Collectors.toList() );
+	}
+
+	private static void mergeModuleDerivedMappings( Map<String, Path> mappings, List<Path> moduleDirs ) {
+		if ( mappings == null || moduleDirs == null || moduleDirs.isEmpty() ) {
+			return;
+		}
+		for ( Path moduleDir : moduleDirs ) {
+			if ( moduleDir == null || !Files.isDirectory( moduleDir ) ) {
+				continue;
+			}
+			mergeModuleMappingForRoot( mappings, moduleDir );
+			try ( var stream = Files.list( moduleDir ) ) {
+				stream.filter( Files::isDirectory ).forEach( child -> mergeModuleMappingForRoot( mappings, child ) );
+			} catch ( IOException ignored ) {
+				// Best effort; explicit mappings from initialize options still apply.
+			}
+		}
+	}
+
+	private static void mergeModuleMappingForRoot( Map<String, Path> mappings, Path moduleRoot ) {
+		Path moduleConfig = Files.isRegularFile( moduleRoot.resolve( "ModuleConfig.bx" ) )
+		    ? moduleRoot.resolve( "ModuleConfig.bx" )
+		    : moduleRoot.resolve( "ModuleConfig.cfc" );
+		if ( !Files.isRegularFile( moduleConfig ) ) {
+			return;
+		}
+		String alias = extractModuleMappingAlias( moduleConfig );
+		if ( alias == null || alias.isBlank() ) {
+			return;
+		}
+		mappings.putIfAbsent( canonicalizeAlias( alias ), moduleRoot.toAbsolutePath().normalize() );
+	}
+
+	private static String extractModuleMappingAlias( Path moduleConfigPath ) {
+		try {
+			String	contents	= Files.readString( moduleConfigPath, StandardCharsets.UTF_8 );
+			Matcher	matcher		= MODULE_MAPPING_PATTERN.matcher( contents );
+			if ( matcher.find() ) {
+				return matcher.group( 2 );
+			}
+		} catch ( IOException ignored ) {
+			// Best effort only.
+		}
+		return null;
+	}
+
+	private static String canonicalizeAlias( String rawAlias ) {
+		if ( rawAlias == null || rawAlias.isBlank() ) {
+			return "";
+		}
+		String alias = rawAlias.trim().replace( '\\', '/' );
+		while ( alias.startsWith( "/" ) ) {
+			alias = alias.substring( 1 );
+		}
+		while ( alias.endsWith( "/" ) ) {
+			alias = alias.substring( 0, alias.length() - 1 );
+		}
+		return alias.toLowerCase( Locale.ROOT );
+	}
+
+	private static String asString( Object value ) {
+		if ( value == null ) {
+			return null;
+		}
+		String text = String.valueOf( value ).trim();
+		return text.isEmpty() ? null : text;
+	}
+
+	private static Path toPath( Object rawValue, Path sourceDir, Path rootPath ) {
+		String rawPath = asString( rawValue );
+		if ( rawPath == null ) {
+			return null;
+		}
+		try {
+			Path candidate = Paths.get( rawPath );
+			if ( candidate.isAbsolute() ) {
+				return normalizePath( candidate );
+			}
+			if ( rawPath.startsWith( "/" ) || rawPath.startsWith( "\\" ) ) {
+				String relativeFromRoot = rawPath.replaceFirst( "^[\\\\/]+", "" );
+				return normalizePath( rootPath.resolve( relativeFromRoot ) );
+			}
+			return normalizePath( sourceDir.resolve( candidate ) );
+		} catch ( Exception e ) {
+			return null;
+		}
+	}
+
+	private static Path normalizePath( Path path ) {
+		return path == null ? null : path.toAbsolutePath().normalize();
+	}
+
+	private static String computeFallbackHash( Path rootPath, Map<String, Path> mappings, List<Path> moduleDirs ) {
+		return Integer.toHexString( Objects.hash( rootPath, mappings, moduleDirs ) );
+	}
+}

--- a/src/main/java/ortus/boxlang/lsp/workspace/ProjectContextProvider.java
+++ b/src/main/java/ortus/boxlang/lsp/workspace/ProjectContextProvider.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -61,6 +62,7 @@ import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.IBoxDocumentableNode;
 import ortus.boxlang.compiler.ast.Point;
 import ortus.boxlang.compiler.ast.comment.BoxDocComment;
+import ortus.boxlang.compiler.ast.expression.BoxArgument;
 import ortus.boxlang.compiler.ast.expression.BoxDotAccess;
 import ortus.boxlang.compiler.ast.expression.BoxFQN;
 import ortus.boxlang.compiler.ast.expression.BoxFunctionInvocation;
@@ -137,6 +139,8 @@ public class ProjectContextProvider {
 	private long								WorkspaceDiagnosticReportId	= 1;
 	private List<DiagnosticReport>				cachedDiagnosticReports		= new CopyOnWriteArrayList<DiagnosticReport>();
 	private final SemanticTokensBuilder			semanticTokensBuilder		= new SemanticTokensBuilder();
+	private volatile ProjectAppContext			appContext					= ProjectAppContext.empty();
+	private final ClassReferenceResolver		classReferenceResolver		= new ClassReferenceResolver( this );
 
 	private boolean								shouldPublishDiagnostics	= false;
 	private final AtomicBoolean					workspaceParseRunning		= new AtomicBoolean( false );
@@ -173,14 +177,9 @@ public class ProjectContextProvider {
 	public ProjectIndex getIndex() {
 		if ( projectIndex == null ) {
 			projectIndex = new ProjectIndex();
-			// Initialize with workspace root if available
-			if ( workspaceFolders != null && !workspaceFolders.isEmpty() ) {
-				try {
-					Path workspaceRoot = Path.of( new URI( workspaceFolders.getFirst().getUri() ) );
-					projectIndex.initialize( workspaceRoot );
-				} catch ( Exception e ) {
-					App.logger.warn( "Failed to initialize project index with workspace root", e );
-				}
+			Path workspaceRoot = resolveWorkspaceRoot();
+			if ( workspaceRoot != null ) {
+				projectIndex.initialize( workspaceRoot );
 			}
 		}
 		return projectIndex;
@@ -316,7 +315,36 @@ public class ProjectContextProvider {
 	}
 
 	public Map<String, Path> getMappings() {
-		return new HashMap<>();
+		return new HashMap<>( appContext.mappings() );
+	}
+
+	public ProjectAppContext getAppContext() {
+		return appContext;
+	}
+
+	public void setAppContext( ProjectAppContext appContext ) {
+		this.appContext = appContext == null ? ProjectAppContext.empty() : appContext;
+	}
+
+	public void setAppContextFromInitializationOptions( Object initializationOptions ) {
+		Path				workspaceRoot	= resolveWorkspaceRoot();
+		ProjectAppContext	parsedContext	= ProjectAppContext.fromInitializationOptions( initializationOptions, workspaceRoot );
+		setAppContext( parsedContext );
+		App.logger.info(
+		    "Initialized app context: optionsType="
+		        + ( initializationOptions != null ? initializationOptions.getClass().getName() : "null" )
+		        + ", rootPath=" + parsedContext.rootPath()
+		        + ", mappings=" + parsedContext.mappings().size()
+		        + ", moduleDirs=" + parsedContext.moduleDirs().size()
+		);
+	}
+
+	public ClassReferenceResolver getClassReferenceResolver() {
+		return classReferenceResolver;
+	}
+
+	public Optional<IndexedClass> resolveClassReference( String classReference, URI docURI ) {
+		return classReferenceResolver.resolveClass( classReference, docURI );
 	}
 
 	public List<Diagnostic> getFileDiagnostics( URI docURI ) {
@@ -340,6 +368,21 @@ public class ProjectContextProvider {
 
 	public void setWorkspaceFolders( List<WorkspaceFolder> folders ) {
 		this.workspaceFolders = folders;
+	}
+
+	private Path resolveWorkspaceRoot() {
+		if ( appContext != null && appContext.rootPath() != null ) {
+			return appContext.rootPath();
+		}
+		if ( workspaceFolders == null || workspaceFolders.isEmpty() ) {
+			return null;
+		}
+		try {
+			return Path.of( new URI( workspaceFolders.getFirst().getUri() ) );
+		} catch ( Exception e ) {
+			App.logger.warn( "Failed to resolve workspace root from folders", e );
+			return null;
+		}
 	}
 
 	public void setShouldPublishDiagnostics( boolean shouldPublishDiagnostics ) {
@@ -1319,16 +1362,22 @@ public class ProjectContextProvider {
 					        return findMethodDefinition( rootNode, methodInvocation, docURI );
 				        } else if ( node instanceof BoxNew newExpr ) {
 					        // Handle class instantiation - navigate to class definition
-					        return findClassDefinition( newExpr );
+					        return findClassDefinition( newExpr, docURI );
 				        } else if ( node instanceof BoxAnnotation annotation ) {
 					        // Handle extends/implements annotations - navigate to class/interface definition
 					        return findClassDefinitionFromAnnotation( annotation, docURI );
+				        } else if ( node instanceof BoxStringLiteral stringLiteral ) {
+					        // Handle createObject("component", "path.to.Class") class arguments
+					        List<Location> createObjectLocations = findClassDefinitionFromCreateObjectLiteral( stringLiteral, docURI );
+					        if ( !createObjectLocations.isEmpty() ) {
+						        return createObjectLocations;
+					        }
 				        } else if ( node instanceof BoxReturnType returnType ) {
 					        // Handle return type hints - navigate to class definition
 					        return findClassDefinitionFromReturnType( returnType );
 				        } else if ( node instanceof BoxArgumentDeclaration argDecl ) {
 					        // Try to navigate to the type class definition first
-					        List<Location> typeLocations = findClassDefinitionFromArgumentType( argDecl );
+					        List<Location> typeLocations = findClassDefinitionFromArgumentType( argDecl, docURI );
 					        if ( !typeLocations.isEmpty() ) {
 						        return typeLocations;
 					        }
@@ -1337,7 +1386,7 @@ public class ProjectContextProvider {
 					        return createLocationList( argDecl, docURI );
 				        } else if ( node instanceof BoxFQN fqn ) {
 					        // Handle type hints (return type, parameter type, variable type)
-					        return findClassDefinitionFromFQN( fqn );
+					        return findClassDefinitionFromFQN( fqn, docURI );
 				        } else if ( node instanceof BoxImport importNode ) {
 					        // Handle import statements - navigate to imported class/interface definition
 					        return findClassDefinitionFromImport( importNode );
@@ -1390,12 +1439,12 @@ public class ProjectContextProvider {
 			        .map( ( node ) -> {
 				        // Handle identifiers (variables)
 				        if ( node instanceof BoxIdentifier identifier ) {
-					        return findTypeDefinitionFromIdentifier( rootNode, identifier );
+					        return findTypeDefinitionFromIdentifier( rootNode, identifier, docURI );
 				        }
 
 				        // Handle argument declarations with type hints
 				        if ( node instanceof BoxArgumentDeclaration argDecl ) {
-					        return findTypeDefinitionFromArgument( argDecl );
+					        return findTypeDefinitionFromArgument( argDecl, docURI );
 				        }
 
 				        return new ArrayList<Location>();
@@ -1414,7 +1463,7 @@ public class ProjectContextProvider {
 	 *
 	 * @return List containing the type definition location, or empty list if not found or primitive type
 	 */
-	private List<Location> findTypeDefinitionFromIdentifier( BoxNode rootNode, BoxIdentifier identifier ) {
+	private List<Location> findTypeDefinitionFromIdentifier( BoxNode rootNode, BoxIdentifier identifier, URI docURI ) {
 		// First collect variable scope/type information
 		VariableScopeCollectorVisitor scopeCollector = new VariableScopeCollectorVisitor();
 		rootNode.accept( scopeCollector );
@@ -1439,7 +1488,7 @@ public class ProjectContextProvider {
 			String inferredType = typeCollector.getVariableType( varName );
 
 			if ( inferredType != null && !isPrimitiveType( inferredType ) ) {
-				return findClassByNameAndGetLocation( inferredType );
+				return findClassByNameAndGetLocation( inferredType, docURI );
 			}
 
 			return new ArrayList<>();
@@ -1456,7 +1505,7 @@ public class ProjectContextProvider {
 		}
 
 		// Look up the class in the index
-		return findClassByNameAndGetLocation( typeName );
+		return findClassByNameAndGetLocation( typeName, docURI );
 	}
 
 	/**
@@ -1466,14 +1515,14 @@ public class ProjectContextProvider {
 	 *
 	 * @return List containing the type definition location, or empty list if not found or primitive type
 	 */
-	private List<Location> findTypeDefinitionFromArgument( BoxArgumentDeclaration argDecl ) {
+	private List<Location> findTypeDefinitionFromArgument( BoxArgumentDeclaration argDecl, URI docURI ) {
 		String typeName = argDecl.getType() != null ? argDecl.getType().toString() : null;
 
 		if ( typeName == null || typeName.isEmpty() || isPrimitiveType( typeName ) ) {
 			return new ArrayList<>();
 		}
 
-		return findClassByNameAndGetLocation( typeName );
+		return findClassByNameAndGetLocation( typeName, docURI );
 	}
 
 	/**
@@ -1914,13 +1963,22 @@ public class ProjectContextProvider {
 	 *
 	 * @return List containing the class definition location, or empty list if not found
 	 */
-	private List<Location> findClassDefinition( BoxNew newExpr ) {
-		String className = extractClassNameFromNew( newExpr );
-		if ( className == null ) {
+	private List<Location> findClassDefinition( BoxNew newExpr, URI docURI ) {
+		String classReference = extractClassReferenceFromNew( newExpr );
+		if ( classReference == null ) {
 			return new ArrayList<>();
 		}
 
-		return findClassByNameAndGetLocation( className );
+		List<Location> locations = findClassByNameAndGetLocation( classReference, docURI );
+		if ( !locations.isEmpty() ) {
+			return locations;
+		}
+
+		String className = extractClassNameFromNew( newExpr );
+		if ( className == null || className.equalsIgnoreCase( classReference ) ) {
+			return locations;
+		}
+		return findClassByNameAndGetLocation( className, docURI );
 	}
 
 	/**
@@ -1943,7 +2001,7 @@ public class ProjectContextProvider {
 		if ( annotation.getValue() instanceof BoxStringLiteral strLiteral ) {
 			className = strLiteral.getValue();
 		} else if ( annotation.getValue() instanceof BoxFQN fqn ) {
-			className = extractClassNameFromFQN( fqn );
+			className = extractClassReferenceFromFQN( fqn );
 		} else if ( annotation.getValue() != null ) {
 			className	= annotation.getValue().getSourceText();
 			// Clean up quotes if present
@@ -1965,6 +2023,69 @@ public class ProjectContextProvider {
 		return findClassByNameAndGetLocation( className, docURI );
 	}
 
+	private List<Location> findClassDefinitionFromCreateObjectLiteral( BoxStringLiteral literal, URI docURI ) {
+		if ( literal == null ) {
+			return new ArrayList<>();
+		}
+		BoxFunctionInvocation invocation = literal.getFirstAncestorOfType( BoxFunctionInvocation.class );
+		if ( invocation == null || invocation.getName() == null || !invocation.getName().equalsIgnoreCase( "createObject" ) ) {
+			return new ArrayList<>();
+		}
+
+		List<BoxArgument> args = invocation.getArguments();
+		if ( args == null || args.isEmpty() ) {
+			return new ArrayList<>();
+		}
+
+		String		positionalType	= null;
+		BoxArgument	classArgument	= null;
+
+		for ( int i = 0; i < args.size(); i++ ) {
+			BoxArgument argument = args.get( i );
+			if ( argument == null ) {
+				continue;
+			}
+			String argumentName = normalizeCreateObjectArgumentName( extractArgumentName( argument ) );
+			if ( i == 0 && argumentName == null ) {
+				positionalType = extractStringLikeValue( argument.getValue() );
+			}
+			if ( argument.getValue() != literal ) {
+				continue;
+			}
+			if ( argumentName != null ) {
+				if ( argumentName.equals( "class" ) || argumentName.equals( "classname" ) || argumentName.equals( "path" )
+				    || argumentName.equals( "component" ) ) {
+					classArgument = argument;
+					break;
+				}
+				return new ArrayList<>();
+			}
+			if ( i == 1 ) {
+				classArgument = argument;
+				break;
+			}
+			return new ArrayList<>();
+		}
+
+		if ( classArgument == null ) {
+			return new ArrayList<>();
+		}
+
+		String classReference = extractStringLikeValue( classArgument.getValue() );
+		if ( classReference == null || classReference.isBlank() ) {
+			return new ArrayList<>();
+		}
+
+		String objectType = resolveCreateObjectType( args, positionalType );
+		if ( objectType != null ) {
+			String normalizedType = objectType.trim().toLowerCase( Locale.ROOT );
+			if ( normalizedType.equals( "java" ) || normalizedType.startsWith( "java:" ) ) {
+				return new ArrayList<>();
+			}
+		}
+		return findClassByNameAndGetLocation( classReference, docURI );
+	}
+
 	/**
 	 * Find the definition location for a class from a BoxFQN node.
 	 * Handles type hints in return types, parameter types, and variable types.
@@ -1973,13 +2094,82 @@ public class ProjectContextProvider {
 	 *
 	 * @return List containing the class definition location, or empty list if not found
 	 */
-	private List<Location> findClassDefinitionFromFQN( BoxFQN fqn ) {
-		String className = extractClassNameFromFQN( fqn );
-		if ( className == null ) {
+	private List<Location> findClassDefinitionFromFQN( BoxFQN fqn, URI docURI ) {
+		String classReference = extractClassReferenceFromFQN( fqn );
+		if ( classReference == null ) {
 			return new ArrayList<>();
 		}
 
-		return findClassByNameAndGetLocation( className );
+		List<Location> locations = findClassByNameAndGetLocation( classReference, docURI );
+		if ( !locations.isEmpty() ) {
+			return locations;
+		}
+
+		String className = extractClassNameFromFQN( fqn );
+		if ( className == null || className.equalsIgnoreCase( classReference ) ) {
+			return locations;
+		}
+		return findClassByNameAndGetLocation( className, docURI );
+	}
+
+	private String resolveCreateObjectType( List<BoxArgument> args, String positionalType ) {
+		for ( BoxArgument argument : args ) {
+			if ( argument == null ) {
+				continue;
+			}
+			String argumentName = normalizeCreateObjectArgumentName( extractArgumentName( argument ) );
+			if ( argumentName != null && argumentName.equals( "type" ) ) {
+				return extractStringLikeValue( argument.getValue() );
+			}
+		}
+		return positionalType;
+	}
+
+	private String normalizeCreateObjectArgumentName( String argumentName ) {
+		if ( argumentName == null ) {
+			return null;
+		}
+		String normalized = argumentName.trim();
+		return normalized.isEmpty() ? null : normalized.toLowerCase( Locale.ROOT );
+	}
+
+	private String extractArgumentName( BoxArgument argument ) {
+		if ( argument == null || argument.getName() == null ) {
+			return null;
+		}
+		BoxNode nameNode = argument.getName();
+		if ( nameNode instanceof BoxIdentifier identifier ) {
+			return identifier.getName();
+		}
+		if ( nameNode instanceof BoxStringLiteral literal ) {
+			return literal.getValue();
+		}
+		return cleanQuotedText( nameNode.getSourceText() );
+	}
+
+	private String extractStringLikeValue( BoxNode valueNode ) {
+		if ( valueNode == null ) {
+			return null;
+		}
+		if ( valueNode instanceof BoxStringLiteral stringLiteral ) {
+			return stringLiteral.getValue();
+		}
+		if ( valueNode instanceof BoxFQN fqn ) {
+			return extractClassReferenceFromFQN( fqn );
+		}
+		return cleanQuotedText( valueNode.getSourceText() );
+	}
+
+	private String cleanQuotedText( String sourceText ) {
+		if ( sourceText == null ) {
+			return null;
+		}
+		String cleaned = sourceText.trim();
+		if ( cleaned.length() >= 2 && ( ( cleaned.startsWith( "\"" ) && cleaned.endsWith( "\"" ) )
+		    || ( cleaned.startsWith( "'" ) && cleaned.endsWith( "'" ) ) ) ) {
+			cleaned = cleaned.substring( 1, cleaned.length() - 1 );
+		}
+		return cleaned.trim();
 	}
 
 	/**
@@ -2100,7 +2290,7 @@ public class ProjectContextProvider {
 	 *
 	 * @return List containing the class definition location, or empty list if not found
 	 */
-	private List<Location> findClassDefinitionFromArgumentType( BoxArgumentDeclaration argDecl ) {
+	private List<Location> findClassDefinitionFromArgumentType( BoxArgumentDeclaration argDecl, URI docURI ) {
 		String type = argDecl.getType();
 		if ( type == null || type.isEmpty() ) {
 			return new ArrayList<>();
@@ -2113,7 +2303,7 @@ public class ProjectContextProvider {
 			className = type.substring( lastDot + 1 );
 		}
 
-		return findClassByNameAndGetLocation( className );
+		return findClassByNameAndGetLocation( className, docURI );
 	}
 
 	/**
@@ -2167,40 +2357,7 @@ public class ProjectContextProvider {
 		if ( className == null || className.isEmpty() ) {
 			return new ArrayList<>();
 		}
-
-		ProjectIndex	index		= getIndex();
-		var				classOpt	= index.findClassByName( className );
-
-		// Try by FQN if simple name lookup failed
-		if ( classOpt.isEmpty() ) {
-			classOpt = index.findClassByFQN( className );
-		}
-
-		// If still not found and className contains a dot (potential relative path),
-		// try resolving relative to the current file's package
-		if ( classOpt.isEmpty() && className.contains( "." ) && docURI != null ) {
-			String currentPackage = getCurrentPackageFromURI( docURI );
-			if ( currentPackage != null && !currentPackage.isEmpty() ) {
-				String qualifiedName = currentPackage + "." + className;
-				classOpt = index.findClassByFQN( qualifiedName );
-			}
-		}
-
-		if ( classOpt.isEmpty() ) {
-			return new ArrayList<>();
-		}
-
-		IndexedClass indexedClass = classOpt.get();
-
-		if ( indexedClass.fileUri() == null || indexedClass.location() == null ) {
-			return new ArrayList<>();
-		}
-
-		Location location = new Location();
-		location.setUri( indexedClass.fileUri() );
-		location.setRange( indexedClass.location() );
-
-		return List.of( location );
+		return classReferenceResolver.resolveLocation( className, docURI );
 	}
 
 	/**
@@ -2573,9 +2730,9 @@ public class ProjectContextProvider {
 
 			    // Handle new expressions (class instantiation) - e.g., new UserService()
 			    if ( target instanceof BoxNew newExpr ) {
-				    String className = extractClassNameFromNew( newExpr );
-				    if ( className != null ) {
-					    var indexedClassOpt = getIndex().findClassByName( className );
+				    String classReference = extractClassReferenceFromNew( newExpr );
+				    if ( classReference != null ) {
+					    var indexedClassOpt = resolveClassReference( classReference, docURI );
 					    if ( indexedClassOpt.isPresent() ) {
 						    return buildHoverForClass( indexedClassOpt.get() );
 					    }
@@ -2584,9 +2741,9 @@ public class ProjectContextProvider {
 
 			    // Handle fully qualified names (class references in type hints, extends, implements, etc.)
 			    if ( target instanceof BoxFQN fqn ) {
-				    String className = extractClassNameFromFQN( fqn );
-				    if ( className != null ) {
-					    var indexedClassOpt = getIndex().findClassByName( className );
+				    String classReference = extractClassReferenceFromFQN( fqn );
+				    if ( classReference != null ) {
+					    var indexedClassOpt = resolveClassReference( classReference, docURI );
 					    if ( indexedClassOpt.isPresent() ) {
 						    return buildHoverForClass( indexedClassOpt.get() );
 					    }
@@ -3619,37 +3776,46 @@ public class ProjectContextProvider {
 	 * Extract the class name from a BoxNew expression.
 	 */
 	private String extractClassNameFromNew( BoxNew newExpr ) {
+		String classReference = extractClassReferenceFromNew( newExpr );
+		if ( classReference == null ) {
+			return null;
+		}
+		int	lastDot			= classReference.lastIndexOf( '.' );
+		int	lastColon		= classReference.lastIndexOf( ':' );
+		int	lastSeparator	= Math.max( lastDot, lastColon );
+		if ( lastSeparator >= 0 && lastSeparator < classReference.length() - 1 ) {
+			return classReference.substring( lastSeparator + 1 );
+		}
+		return classReference;
+	}
+
+	/**
+	 * Extract the full class reference from a BoxNew expression.
+	 */
+	private String extractClassReferenceFromNew( BoxNew newExpr ) {
 		BoxNode expression = newExpr.getExpression();
 
 		if ( expression instanceof BoxFQN fqn ) {
-			return extractClassNameFromFQN( fqn );
+			return extractClassReferenceFromFQN( fqn );
 		}
 
-		// Try to get the source text as a fallback
-		if ( expression != null ) {
-			String sourceText = expression.getSourceText();
-			if ( sourceText != null ) {
-				sourceText = sourceText.trim();
-				int	lastDot			= sourceText.lastIndexOf( '.' );
-				int	lastColon		= sourceText.lastIndexOf( ':' );
-				int	lastSeparator	= Math.max( lastDot, lastColon );
-
-				if ( lastSeparator >= 0 && lastSeparator < sourceText.length() - 1 ) {
-					return sourceText.substring( lastSeparator + 1 );
-				}
-				return sourceText;
-			}
+		if ( expression == null ) {
+			return null;
 		}
-
-		return null;
+		String sourceText = expression.getSourceText();
+		if ( sourceText == null ) {
+			return null;
+		}
+		sourceText = sourceText.trim();
+		return sourceText.isEmpty() ? null : sourceText;
 	}
 
 	/**
 	 * Extract the class name from a BoxFQN node.
 	 */
 	private String extractClassNameFromFQN( BoxFQN fqn ) {
-		String fullPath = fqn.getValue();
-		if ( fullPath == null || fullPath.isEmpty() ) {
+		String fullPath = extractClassReferenceFromFQN( fqn );
+		if ( fullPath == null ) {
 			return null;
 		}
 
@@ -3662,6 +3828,17 @@ public class ProjectContextProvider {
 			return fullPath.substring( lastSeparator + 1 );
 		}
 		return fullPath;
+	}
+
+	/**
+	 * Extract the full class reference path from a BoxFQN node.
+	 */
+	private String extractClassReferenceFromFQN( BoxFQN fqn ) {
+		if ( fqn == null || fqn.getValue() == null ) {
+			return null;
+		}
+		String fullPath = fqn.getValue().trim();
+		return fullPath.isEmpty() ? null : fullPath;
 	}
 
 	/**
@@ -3679,7 +3856,7 @@ public class ProjectContextProvider {
 		if ( annotation.getValue() instanceof BoxStringLiteral strLiteral ) {
 			className = strLiteral.getValue();
 		} else if ( annotation.getValue() instanceof BoxFQN fqn ) {
-			className = extractClassNameFromFQN( fqn );
+			className = extractClassReferenceFromFQN( fqn );
 		} else if ( annotation.getValue() != null ) {
 			className	= annotation.getValue().getSourceText();
 			// Clean up quotes if present
@@ -3704,29 +3881,7 @@ public class ProjectContextProvider {
 	 * Tries simple name, FQN, and relative package resolution.
 	 */
 	private java.util.Optional<IndexedClass> findClassByNameWithRelativeResolution( String className, URI docURI ) {
-		if ( className == null || className.isEmpty() ) {
-			return java.util.Optional.empty();
-		}
-
-		ProjectIndex	index		= getIndex();
-		var				classOpt	= index.findClassByName( className );
-
-		// Try by FQN if simple name lookup failed
-		if ( classOpt.isEmpty() ) {
-			classOpt = index.findClassByFQN( className );
-		}
-
-		// If still not found and className contains a dot (potential relative path),
-		// try resolving relative to the current file's package
-		if ( classOpt.isEmpty() && className.contains( "." ) && docURI != null ) {
-			String currentPackage = getCurrentPackageFromURI( docURI );
-			if ( currentPackage != null && !currentPackage.isEmpty() ) {
-				String qualifiedName = currentPackage + "." + className;
-				classOpt = index.findClassByFQN( qualifiedName );
-			}
-		}
-
-		return classOpt;
+		return resolveClassReference( className, docURI );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/lsp/workspace/visitors/FindDefinitionTargetVisitor.java
+++ b/src/main/java/ortus/boxlang/lsp/workspace/visitors/FindDefinitionTargetVisitor.java
@@ -7,6 +7,7 @@ import ortus.boxlang.compiler.ast.BoxInterface;
 import ortus.boxlang.compiler.ast.BoxNode;
 import ortus.boxlang.compiler.ast.BoxScript;
 import ortus.boxlang.compiler.ast.BoxTemplate;
+import ortus.boxlang.compiler.ast.expression.BoxArgument;
 import ortus.boxlang.compiler.ast.expression.BoxDotAccess;
 import ortus.boxlang.compiler.ast.expression.BoxFQN;
 import ortus.boxlang.compiler.ast.expression.BoxFunctionInvocation;
@@ -303,12 +304,10 @@ public class FindDefinitionTargetVisitor extends VoidBoxVisitor {
 
 		// Handle extends and implements annotations
 		if ( key.equals( "extends" ) || key.equals( "implements" ) ) {
-			// Check if cursor is on the value (the class/interface name)
-			if ( node.getValue() != null && BLASTTools.containsPosition( node.getValue(), line, column ) ) {
-				// Set the annotation as target so we can extract the class name from it
-				this.definitionTarget = node;
-				return;
-			}
+			// Resolve from anywhere within the annotation (key, equals, value, quotes)
+			// so Cmd/Ctrl+Click on `extends`/`implements` consistently navigates.
+			this.definitionTarget = node;
+			return;
 		}
 
 		// Visit children for other annotations
@@ -337,8 +336,51 @@ public class FindDefinitionTargetVisitor extends VoidBoxVisitor {
 			}
 		}
 
+		// Handle class argument in createObject("component", "path.to.Class")
+		if ( isCreateObjectClassArgument( node ) ) {
+			this.definitionTarget = node;
+			return;
+		}
+
 		// For other string literals, don't set as target
 		visitChildren( node );
+	}
+
+	private boolean isCreateObjectClassArgument( BoxStringLiteral literal ) {
+		BoxFunctionInvocation invocation = literal.getFirstAncestorOfType( BoxFunctionInvocation.class );
+		if ( invocation == null || invocation.getName() == null || !invocation.getName().equalsIgnoreCase( "createObject" ) ) {
+			return false;
+		}
+		int index = 0;
+		for ( BoxArgument argument : invocation.getArguments() ) {
+			if ( argument == null || argument.getValue() != literal ) {
+				index++;
+				continue;
+			}
+			String argumentName = extractArgumentName( argument );
+			if ( argumentName != null ) {
+				return argumentName.equalsIgnoreCase( "class" )
+				    || argumentName.equalsIgnoreCase( "classname" )
+				    || argumentName.equalsIgnoreCase( "path" )
+				    || argumentName.equalsIgnoreCase( "component" );
+			}
+			return index == 1;
+		}
+		return false;
+	}
+
+	private String extractArgumentName( BoxArgument argument ) {
+		if ( argument == null || argument.getName() == null ) {
+			return null;
+		}
+		BoxNode nameNode = argument.getName();
+		if ( nameNode instanceof BoxIdentifier identifier ) {
+			return identifier.getName();
+		}
+		if ( nameNode instanceof BoxStringLiteral literal ) {
+			return literal.getValue();
+		}
+		return nameNode.getSourceText();
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/lsp/workspace/visitors/SemanticErrorDiagnosticVisitor.java
+++ b/src/main/java/ortus/boxlang/lsp/workspace/visitors/SemanticErrorDiagnosticVisitor.java
@@ -17,6 +17,7 @@
  */
 package ortus.boxlang.lsp.workspace.visitors;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -45,9 +46,9 @@ import ortus.boxlang.lsp.lint.rules.DuplicatePropertyRule;
 import ortus.boxlang.lsp.lint.rules.InvalidExtendsRule;
 import ortus.boxlang.lsp.lint.rules.InvalidImplementsRule;
 import ortus.boxlang.lsp.workspace.BLASTTools;
+import ortus.boxlang.lsp.workspace.ClassReferenceResolver;
 import ortus.boxlang.lsp.workspace.FileParseResult;
 import ortus.boxlang.lsp.workspace.ProjectContextProvider;
-import ortus.boxlang.lsp.workspace.index.ProjectIndex;
 
 /**
  * Visitor for detecting semantic errors in BoxLang code.
@@ -62,10 +63,11 @@ import ortus.boxlang.lsp.workspace.index.ProjectIndex;
  */
 public class SemanticErrorDiagnosticVisitor extends SourceCodeVisitor {
 
-	private List<Diagnostic>	diagnostics			= new ArrayList<>();
-	private Set<String>			seenMethods			= new HashSet<>();
-	private Set<String>			seenProperties		= new HashSet<>();
-	private String				currentClassName	= null;
+	private List<Diagnostic>				diagnostics				= new ArrayList<>();
+	private Set<String>						seenMethods				= new HashSet<>();
+	private Set<String>						seenProperties			= new HashSet<>();
+	private String							currentClassName		= null;
+	private final ClassReferenceResolver	classReferenceResolver	= ProjectContextProvider.getInstance().getClassReferenceResolver();
 
 	@Override
 	public List<Diagnostic> getDiagnostics() {
@@ -219,55 +221,6 @@ public class SemanticErrorDiagnosticVisitor extends SourceCodeVisitor {
 	}
 
 	/**
-	 * Get the package (directory path) of the current file relative to workspace root.
-	 * For example, if file is at "subpackage/BaseType.bx", returns "subpackage".
-	 * Returns null if package cannot be determined.
-	 */
-	private String getCurrentPackage() {
-		if ( this.filePath == null ) {
-			return null;
-		}
-
-		try {
-			// Get workspace root
-			var folders = ProjectContextProvider.getInstance().getWorkspaceFolders();
-			if ( folders == null || folders.isEmpty() ) {
-				return null;
-			}
-
-			java.net.URI		workspaceUri	= new java.net.URI( folders.get( 0 ).getUri() );
-			java.nio.file.Path	workspaceRoot	= java.nio.file.Paths.get( workspaceUri );
-
-			// Convert filePath to Path (handle both URI and file path formats)
-			java.nio.file.Path	filePath;
-			if ( this.filePath.startsWith( "file:" ) ) {
-				filePath = java.nio.file.Paths.get( new java.net.URI( this.filePath ) );
-			} else {
-				filePath = java.nio.file.Paths.get( this.filePath );
-			}
-
-			// Get relative path from workspace root
-			java.nio.file.Path	relativePath	= workspaceRoot.relativize( filePath );
-			String				pathStr			= relativePath.toString();
-
-			// Get the directory part (without filename)
-			int					lastSlash		= Math.max( pathStr.lastIndexOf( '/' ), pathStr.lastIndexOf( '\\' ) );
-			if ( lastSlash < 0 ) {
-				// File is in root directory
-				return null;
-			}
-
-			String packagePath = pathStr.substring( 0, lastSlash );
-
-			// Convert path separators to dots
-			return packagePath.replace( '/', '.' ).replace( '\\', '.' );
-		} catch ( Exception e ) {
-			// If we can't determine package, return null
-			return null;
-		}
-	}
-
-	/**
 	 * Create a range that covers from the "class" or "interface" keyword to the opening brace "{".
 	 * This provides a more precise diagnostic location for class declaration issues.
 	 *
@@ -316,29 +269,8 @@ public class SemanticErrorDiagnosticVisitor extends SourceCodeVisitor {
 	}
 
 	private void validateExtendsReference( String className, BoxNode node ) {
-		ProjectIndex index = ProjectContextProvider.getInstance().getIndex();
-		if ( index == null ) {
-			return;
-		}
-
-		// Try to find by simple name first
-		var foundClass = index.findClassByName( className );
-		if ( foundClass.isEmpty() ) {
-			// Try by FQN
-			foundClass = index.findClassByFQN( className );
-		}
-
-		// If still not found and className contains a dot (potential relative path),
-		// try resolving relative to the current file's package
-		if ( foundClass.isEmpty() && className.contains( "." ) ) {
-			String currentPackage = getCurrentPackage();
-			if ( currentPackage != null && !currentPackage.isEmpty() ) {
-				String qualifiedName = currentPackage + "." + className;
-				foundClass = index.findClassByFQN( qualifiedName );
-			}
-		}
-
-		if ( foundClass.isEmpty() ) {
+		URI currentDocUri = getCurrentDocumentUri();
+		if ( classReferenceResolver.resolveClass( className, currentDocUri ).isEmpty() ) {
 			Diagnostic diagnostic = new Diagnostic(
 			    getClassDeclarationRange( node ),
 			    "Class or interface '" + className + "' not found (extends reference).",
@@ -351,29 +283,8 @@ public class SemanticErrorDiagnosticVisitor extends SourceCodeVisitor {
 	}
 
 	private void validateImplementsReference( String interfaceName, BoxNode node ) {
-		ProjectIndex index = ProjectContextProvider.getInstance().getIndex();
-		if ( index == null ) {
-			return;
-		}
-
-		// Try to find by simple name first
-		var foundClass = index.findClassByName( interfaceName );
-		if ( foundClass.isEmpty() ) {
-			// Try by FQN
-			foundClass = index.findClassByFQN( interfaceName );
-		}
-
-		// If still not found and interfaceName contains a dot (potential relative path),
-		// try resolving relative to the current file's package
-		if ( foundClass.isEmpty() && interfaceName.contains( "." ) ) {
-			String currentPackage = getCurrentPackage();
-			if ( currentPackage != null && !currentPackage.isEmpty() ) {
-				String qualifiedName = currentPackage + "." + interfaceName;
-				foundClass = index.findClassByFQN( qualifiedName );
-			}
-		}
-
-		if ( foundClass.isEmpty() ) {
+		URI currentDocUri = getCurrentDocumentUri();
+		if ( classReferenceResolver.resolveClass( interfaceName, currentDocUri ).isEmpty() ) {
 			Diagnostic diagnostic = new Diagnostic(
 			    getClassDeclarationRange( node ),
 			    "Interface '" + interfaceName + "' not found (implements reference).",
@@ -382,6 +293,20 @@ public class SemanticErrorDiagnosticVisitor extends SourceCodeVisitor {
 			    InvalidImplementsRule.ID
 			);
 			diagnostics.add( diagnostic );
+		}
+	}
+
+	private URI getCurrentDocumentUri() {
+		if ( filePath == null || filePath.isBlank() ) {
+			return null;
+		}
+		try {
+			if ( filePath.startsWith( "file:" ) ) {
+				return new URI( filePath );
+			}
+			return java.nio.file.Paths.get( filePath ).toUri();
+		} catch ( Exception e ) {
+			return null;
 		}
 	}
 

--- a/src/test/java/ortus/boxlang/lsp/ClassDefinitionTest.java
+++ b/src/test/java/ortus/boxlang/lsp/ClassDefinitionTest.java
@@ -272,4 +272,49 @@ public class ClassDefinitionTest extends BaseTest {
 			Files.deleteIfExists( tempFile );
 		}
 	}
+
+	@Test
+	void testGoToDefinitionOnCreateObjectComponentClassArgument() throws Exception {
+		Path	tempFile	= testDir.resolve( "TempCreateObjectClassRef.bx" );
+		String	content		= """
+		                      class {
+		                          function build() {
+		                              return createObject( "component", "User" );
+		                          }
+		                      }
+		                      """;
+		Files.writeString( tempFile, content );
+
+		try {
+			svc.didOpen( new DidOpenTextDocumentParams(
+			    new TextDocumentItem( tempFile.toUri().toString(), "boxlang", 1, content ) ) );
+
+			int userOffset = content.indexOf( "\"User\"" );
+			assertThat( userOffset ).isAtLeast( 0 );
+
+			int	line	= 0;
+			int	column	= 0;
+			for ( int i = 0; i < userOffset + 2; i++ ) {
+				if ( content.charAt( i ) == '\n' ) {
+					line++;
+					column = 0;
+				} else {
+					column++;
+				}
+			}
+
+			DefinitionParams params = new DefinitionParams();
+			params.setTextDocument( new TextDocumentIdentifier( tempFile.toUri().toString() ) );
+			params.setPosition( new Position( line, column ) );
+
+			var result = svc.definition( params ).get();
+
+			assertThat( result ).isNotNull();
+			assertThat( result.getLeft() ).isNotNull();
+			assertThat( result.getLeft().size() ).isGreaterThan( 0 );
+			assertThat( result.getLeft().getFirst().getUri() ).isEqualTo( testDir.resolve( "User.bx" ).toUri().toString() );
+		} finally {
+			Files.deleteIfExists( tempFile );
+		}
+	}
 }

--- a/src/test/java/ortus/boxlang/lsp/LanguageServerAppContextInitializationTest.java
+++ b/src/test/java/ortus/boxlang/lsp/LanguageServerAppContextInitializationTest.java
@@ -1,0 +1,243 @@
+package ortus.boxlang.lsp;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.gson.JsonParser;
+
+import ortus.boxlang.lsp.workspace.ProjectAppContext;
+import ortus.boxlang.lsp.workspace.ProjectContextProvider;
+
+public class LanguageServerAppContextInitializationTest extends BaseTest {
+
+	@TempDir
+	Path workspaceRoot;
+
+	@BeforeEach
+	void setUp() {
+		ProjectContextProvider provider = ProjectContextProvider.getInstance();
+		provider.setAppContext( ProjectAppContext.empty() );
+	}
+
+	@Test
+	void testInitializeStoresAppContextFromInitializationOptions() throws Exception {
+		Path				mappedRoot	= workspaceRoot.resolve( "modules_app/api-root" );
+		Path				moduleDir	= workspaceRoot.resolve( "modules_app" );
+
+		LanguageServer		server		= new LanguageServer();
+
+		InitializeParams	params		= new InitializeParams();
+		params.setCapabilities( new ClientCapabilities() );
+		params.setWorkspaceFolders( List.of( new WorkspaceFolder( workspaceRoot.toUri().toString(), "workspace" ) ) );
+		params.setInitializationOptions(
+		    Map.of(
+		        "boxlang",
+		        Map.of(
+		            "appContext",
+		            Map.of(
+		                "rootPath",
+		                workspaceRoot.toString(),
+		                "mappings",
+		                Map.of( "api", mappedRoot.toString() ),
+		                "moduleDirs",
+		                List.of( moduleDir.toString() ),
+		                "contextHash",
+		                "app-context-hash"
+		            )
+		        )
+		    )
+		);
+
+		server.initialize( params ).get();
+
+		ProjectAppContext appContext = ProjectContextProvider.getInstance().getAppContext();
+		assertThat( appContext.rootPath() ).isEqualTo( workspaceRoot.toAbsolutePath().normalize() );
+		assertThat( appContext.contextHash() ).isEqualTo( "app-context-hash" );
+		assertThat( appContext.mappings().get( "api" ) ).isEqualTo( mappedRoot.toAbsolutePath().normalize() );
+		assertThat( appContext.moduleDirs() ).contains( moduleDir.toAbsolutePath().normalize() );
+	}
+
+	@Test
+	void testInitializeStoresAppContextFromJsonObjectInitializationOptions() throws Exception {
+		Path	mappedRoot	= workspaceRoot.resolve( "modules_app/api-root" );
+		Path	moduleDir	= workspaceRoot.resolve( "modules_app" );
+		Files.createDirectories( moduleDir );
+
+		LanguageServer		server	= new LanguageServer();
+		InitializeParams	params	= new InitializeParams();
+		params.setCapabilities( new ClientCapabilities() );
+		params.setWorkspaceFolders( List.of( new WorkspaceFolder( workspaceRoot.toUri().toString(), "workspace" ) ) );
+		params.setInitializationOptions(
+		    JsonParser.parseString(
+		        """
+		        {
+		          "boxlang": {
+		            "appContext": {
+		              "rootPath": "%s",
+		              "mappings": { "api": "%s" },
+		              "moduleDirs": [ "%s" ],
+		              "contextHash": "json-app-context-hash"
+		            }
+		          }
+		        }
+		        """.formatted(
+		            workspaceRoot.toString().replace( "\\", "\\\\" ),
+		            mappedRoot.toString().replace( "\\", "\\\\" ),
+		            moduleDir.toString().replace( "\\", "\\\\" )
+		        )
+		    ).getAsJsonObject()
+		);
+
+		server.initialize( params ).get();
+
+		ProjectAppContext appContext = ProjectContextProvider.getInstance().getAppContext();
+		assertThat( appContext.rootPath() ).isEqualTo( workspaceRoot.toAbsolutePath().normalize() );
+		assertThat( appContext.contextHash() ).isEqualTo( "json-app-context-hash" );
+		assertThat( appContext.mappings().get( "api" ) ).isEqualTo( mappedRoot.toAbsolutePath().normalize() );
+		assertThat( appContext.moduleDirs() ).contains( moduleDir.toAbsolutePath().normalize() );
+	}
+
+	@Test
+	void testInitializeDerivesMappingsFromModuleDirectories() throws Exception {
+		Path	moduleDir		= workspaceRoot.resolve( ".boxlang/modules" );
+		Path	testboxModule	= moduleDir.resolve( "testbox" );
+		Files.createDirectories( testboxModule.resolve( "system" ) );
+		Files.writeString(
+		    testboxModule.resolve( "ModuleConfig.bx" ),
+		    """
+		    component {
+		        this.mapping = "testbox";
+		    }
+		    """,
+		    StandardCharsets.UTF_8
+		);
+
+		LanguageServer		server	= new LanguageServer();
+		InitializeParams	params	= new InitializeParams();
+		params.setCapabilities( new ClientCapabilities() );
+		params.setWorkspaceFolders( List.of( new WorkspaceFolder( workspaceRoot.toUri().toString(), "workspace" ) ) );
+		params.setInitializationOptions(
+		    Map.of(
+		        "boxlang",
+		        Map.of(
+		            "appContext",
+		            Map.of(
+		                "rootPath",
+		                workspaceRoot.toString(),
+		                "mappings",
+		                Map.of(),
+		                "moduleDirs",
+		                List.of( moduleDir.toString() ),
+		                "contextHash",
+		                "module-derived-mapping"
+		            )
+		        )
+		    )
+		);
+
+		server.initialize( params ).get();
+
+		ProjectAppContext appContext = ProjectContextProvider.getInstance().getAppContext();
+		assertThat( appContext.mappings().get( "testbox" ) ).isEqualTo( testboxModule.toAbsolutePath().normalize() );
+	}
+
+	@Test
+	void testInitializeDerivesMappingsFromModuleConfigCfc() throws Exception {
+		Path	moduleDir		= workspaceRoot.resolve( ".boxlang/modules" );
+		Path	testboxModule	= moduleDir.resolve( "testbox" );
+		Files.createDirectories( testboxModule.resolve( "system" ) );
+		Files.writeString(
+		    testboxModule.resolve( "ModuleConfig.cfc" ),
+		    """
+		    component {
+		        this.mapping = "testbox";
+		    }
+		    """,
+		    StandardCharsets.UTF_8
+		);
+
+		LanguageServer		server	= new LanguageServer();
+		InitializeParams	params	= new InitializeParams();
+		params.setCapabilities( new ClientCapabilities() );
+		params.setWorkspaceFolders( List.of( new WorkspaceFolder( workspaceRoot.toUri().toString(), "workspace" ) ) );
+		params.setInitializationOptions(
+		    Map.of(
+		        "boxlang",
+		        Map.of(
+		            "appContext",
+		            Map.of(
+		                "rootPath",
+		                workspaceRoot.toString(),
+		                "mappings",
+		                Map.of(),
+		                "moduleDirs",
+		                List.of( moduleDir.toString() ),
+		                "contextHash",
+		                "module-derived-mapping-cfc"
+		            )
+		        )
+		    )
+		);
+
+		server.initialize( params ).get();
+
+		ProjectAppContext appContext = ProjectContextProvider.getInstance().getAppContext();
+		assertThat( appContext.mappings().get( "testbox" ) ).isEqualTo( testboxModule.toAbsolutePath().normalize() );
+	}
+
+	@Test
+	void testInitializeDerivesMappingsFromModuleConfigCfcCfmapping() throws Exception {
+		Path	moduleDir	= workspaceRoot.resolve( ".boxlang/modules" );
+		Path	qbModule	= moduleDir.resolve( "qb" );
+		Files.createDirectories( qbModule.resolve( "models" ) );
+		Files.writeString(
+		    qbModule.resolve( "ModuleConfig.cfc" ),
+		    """
+		    component {
+		        this.cfmapping = "qb";
+		    }
+		    """,
+		    StandardCharsets.UTF_8
+		);
+
+		LanguageServer		server	= new LanguageServer();
+		InitializeParams	params	= new InitializeParams();
+		params.setCapabilities( new ClientCapabilities() );
+		params.setWorkspaceFolders( List.of( new WorkspaceFolder( workspaceRoot.toUri().toString(), "workspace" ) ) );
+		params.setInitializationOptions(
+		    Map.of(
+		        "boxlang",
+		        Map.of(
+		            "appContext",
+		            Map.of(
+		                "rootPath",
+		                workspaceRoot.toString(),
+		                "mappings",
+		                Map.of(),
+		                "moduleDirs",
+		                List.of( moduleDir.toString() ),
+		                "contextHash",
+		                "module-derived-cfmapping-cfc"
+		            )
+		        )
+		    )
+		);
+
+		server.initialize( params ).get();
+
+		ProjectAppContext appContext = ProjectContextProvider.getInstance().getAppContext();
+		assertThat( appContext.mappings().get( "qb" ) ).isEqualTo( qbModule.toAbsolutePath().normalize() );
+	}
+}

--- a/src/test/java/ortus/boxlang/lsp/MappedClassResolutionTest.java
+++ b/src/test/java/ortus/boxlang/lsp/MappedClassResolutionTest.java
@@ -1,0 +1,363 @@
+package ortus.boxlang.lsp;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import ortus.boxlang.lsp.lint.rules.InvalidExtendsRule;
+import ortus.boxlang.lsp.lint.rules.InvalidImplementsRule;
+import ortus.boxlang.lsp.workspace.ProjectAppContext;
+import ortus.boxlang.lsp.workspace.ProjectContextProvider;
+import ortus.boxlang.lsp.workspace.index.ProjectIndex;
+
+public class MappedClassResolutionTest extends BaseTest {
+
+	@TempDir
+	Path							workspaceRoot;
+
+	@TempDir
+	Path							externalRoot;
+
+	private ProjectContextProvider	provider;
+	private ProjectIndex			index;
+	private Path					mappedRoot;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		provider	= ProjectContextProvider.getInstance();
+		index		= new ProjectIndex();
+		index.initialize( workspaceRoot );
+		provider.setIndex( index );
+		provider.setWorkspaceFolders( List.of( new WorkspaceFolder( workspaceRoot.toUri().toString(), "workspace" ) ) );
+
+		mappedRoot = externalRoot.resolve( "mapped-api" );
+		Files.createDirectories( mappedRoot );
+		provider.setAppContext( new ProjectAppContext(
+		    workspaceRoot,
+		    Map.of( "api", mappedRoot ),
+		    List.of(),
+		    "mapped-test-hash"
+		) );
+	}
+
+	@Test
+	void testMappedExtendsAndImplementsDoNotEmitInvalidDiagnostics() throws Exception {
+		Path baseHandler = mappedRoot.resolve( "handlers/BaseHandler.bx" );
+		Files.createDirectories( baseHandler.getParent() );
+		Files.writeString(
+		    baseHandler,
+		    """
+		    class {
+		        function init() { return this; }
+		    }
+		    """
+		);
+
+		Path baseContract = mappedRoot.resolve( "contracts/BaseContract.bx" );
+		Files.createDirectories( baseContract.getParent() );
+		Files.writeString(
+		    baseContract,
+		    """
+		    interface {
+		        function execute();
+		    }
+		    """
+		);
+
+		Path child = workspaceRoot.resolve( "ChildHandler.bx" );
+		Files.writeString(
+		    child,
+		    """
+		    class extends="api.handlers.BaseHandler" implements="api.contracts.BaseContract" {
+		        function execute() { return true; }
+		    }
+		    """
+		);
+
+		List<Diagnostic>	diagnostics				= provider.getFileDiagnostics( child.toUri() );
+
+		boolean				hasInvalidExtends		= diagnostics.stream().anyMatch( this::isInvalidExtendsDiagnostic );
+		boolean				hasInvalidImplements	= diagnostics.stream().anyMatch( this::isInvalidImplementsDiagnostic );
+
+		assertThat( hasInvalidExtends ).isFalse();
+		assertThat( hasInvalidImplements ).isFalse();
+	}
+
+	@Test
+	void testUnresolvedMappingStillEmitsInvalidExtends() throws Exception {
+		provider.setAppContext( new ProjectAppContext( workspaceRoot, Map.of(), List.of(), "no-mappings" ) );
+
+		Path child = workspaceRoot.resolve( "MissingMappedParent.bx" );
+		Files.writeString(
+		    child,
+		    """
+		    class extends="missing.handlers.DoesNotExist" {
+		        function init() { return this; }
+		    }
+		    """
+		);
+
+		List<Diagnostic>	diagnostics			= provider.getFileDiagnostics( child.toUri() );
+		boolean				hasInvalidExtends	= diagnostics.stream().anyMatch( this::isInvalidExtendsDiagnostic );
+
+		assertThat( hasInvalidExtends ).isTrue();
+	}
+
+	@Test
+	void testDefinitionOnMappedClassOutsideWorkspaceLazyIndexesTarget() throws Exception {
+		Path mappedClass = mappedRoot.resolve( "handlers/BaseHandler.bx" );
+		Files.createDirectories( mappedClass.getParent() );
+		Files.writeString(
+		    mappedClass,
+		    """
+		    class {
+		        function init() { return this; }
+		    }
+		    """
+		);
+
+		assertThat( index.findClassByName( "BaseHandler" ) ).isEmpty();
+
+		Path	consumer	= workspaceRoot.resolve( "Consumer.bx" );
+		String	source		= """
+		                      class {
+		                          function run() {
+		                              var handler = new api.handlers.BaseHandler();
+		                              return handler;
+		                          }
+		                      }
+		                      """;
+		Files.writeString( consumer, source );
+
+		BoxLangTextDocumentService svc = new BoxLangTextDocumentService();
+		svc.didOpen( new DidOpenTextDocumentParams(
+		    new TextDocumentItem( consumer.toUri().toString(), "boxlang", 1, source )
+		) );
+
+		int					tokenOffset	= source.indexOf( "BaseHandler" );
+		Position			position	= positionFromOffset( source, tokenOffset + 1 );
+
+		DefinitionParams	params		= new DefinitionParams();
+		params.setTextDocument( new TextDocumentIdentifier( consumer.toUri().toString() ) );
+		params.setPosition( position );
+
+		var result = svc.definition( params ).get();
+
+		assertThat( result ).isNotNull();
+		assertThat( result.isLeft() ).isTrue();
+		assertThat( result.getLeft() ).isNotEmpty();
+		assertThat( result.getLeft().getFirst().getUri() ).isEqualTo( mappedClass.toUri().toString() );
+
+		var indexedClass = index.findClassByName( "BaseHandler" );
+		assertThat( indexedClass ).isPresent();
+		assertThat( indexedClass.get().fileUri() ).isEqualTo( mappedClass.toUri().toString() );
+	}
+
+	@Test
+	void testDefinitionOnMappedCreateObjectClassArgument() throws Exception {
+		Path mappedClass = mappedRoot.resolve( "handlers/BaseHandler.bx" );
+		Files.createDirectories( mappedClass.getParent() );
+		Files.writeString(
+		    mappedClass,
+		    """
+		    class {
+		        function init() { return this; }
+		    }
+		    """
+		);
+
+		Path	consumer	= workspaceRoot.resolve( "CreateObjectConsumer.bx" );
+		String	source		= """
+		                      class {
+		                          function build() {
+		                              return createObject( "component", "api.handlers.BaseHandler" );
+		                          }
+		                      }
+		                      """;
+		Files.writeString( consumer, source );
+
+		BoxLangTextDocumentService svc = new BoxLangTextDocumentService();
+		svc.didOpen( new DidOpenTextDocumentParams(
+		    new TextDocumentItem( consumer.toUri().toString(), "boxlang", 1, source )
+		) );
+
+		int					tokenOffset	= source.indexOf( "api.handlers.BaseHandler" );
+		Position			position	= positionFromOffset( source, tokenOffset + 2 );
+
+		DefinitionParams	params		= new DefinitionParams();
+		params.setTextDocument( new TextDocumentIdentifier( consumer.toUri().toString() ) );
+		params.setPosition( position );
+
+		var result = svc.definition( params ).get();
+
+		assertThat( result ).isNotNull();
+		assertThat( result.isLeft() ).isTrue();
+		assertThat( result.getLeft() ).isNotEmpty();
+		assertThat( result.getLeft().getFirst().getUri() ).isEqualTo( mappedClass.toUri().toString() );
+	}
+
+	@Test
+	void testDefinitionOnMappedExtendsAnnotationKey() throws Exception {
+		Path mappedClass = mappedRoot.resolve( "handlers/BaseSpec.bx" );
+		Files.createDirectories( mappedClass.getParent() );
+		Files.writeString(
+		    mappedClass,
+		    """
+		    class {
+		        function init() { return this; }
+		    }
+		    """
+		);
+
+		Path	consumer	= workspaceRoot.resolve( "ExtendsConsumer.bx" );
+		String	source		= """
+		                      class extends="api.handlers.BaseSpec" {
+		                      }
+		                      """;
+		Files.writeString( consumer, source );
+
+		BoxLangTextDocumentService svc = new BoxLangTextDocumentService();
+		svc.didOpen( new DidOpenTextDocumentParams(
+		    new TextDocumentItem( consumer.toUri().toString(), "boxlang", 1, source )
+		) );
+
+		int					tokenOffset	= source.indexOf( "extends" );
+		Position			position	= positionFromOffset( source, tokenOffset + 1 );
+
+		DefinitionParams	params		= new DefinitionParams();
+		params.setTextDocument( new TextDocumentIdentifier( consumer.toUri().toString() ) );
+		params.setPosition( position );
+
+		var result = svc.definition( params ).get();
+
+		assertThat( result ).isNotNull();
+		assertThat( result.isLeft() ).isTrue();
+		assertThat( result.getLeft() ).isNotEmpty();
+		assertThat( result.getLeft().getFirst().getUri() ).isEqualTo( mappedClass.toUri().toString() );
+	}
+
+	@Test
+	void testDefinitionOnMappedCfcExtendsAnnotationKey() throws Exception {
+		Path mappedClass = mappedRoot.resolve( "system/BaseSpec.cfc" );
+		Files.createDirectories( mappedClass.getParent() );
+		Files.writeString(
+		    mappedClass,
+		    """
+		    component {
+		        function beforeAll() {}
+		    }
+		    """
+		);
+
+		provider.setAppContext( new ProjectAppContext(
+		    workspaceRoot,
+		    Map.of( "testbox", mappedRoot ),
+		    List.of(),
+		    "mapped-cfc-extends"
+		) );
+
+		Path	consumer	= workspaceRoot.resolve( "QueryUtilsSpec.cfc" );
+		String	source		= """
+		                      component extends="testbox.system.BaseSpec" {
+		                      }
+		                      """;
+		Files.writeString( consumer, source );
+
+		BoxLangTextDocumentService svc = new BoxLangTextDocumentService();
+		svc.didOpen( new DidOpenTextDocumentParams(
+		    new TextDocumentItem( consumer.toUri().toString(), "boxlang", 1, source )
+		) );
+
+		int					tokenOffset	= source.indexOf( "extends" );
+		Position			position	= positionFromOffset( source, tokenOffset + 1 );
+
+		DefinitionParams	params		= new DefinitionParams();
+		params.setTextDocument( new TextDocumentIdentifier( consumer.toUri().toString() ) );
+		params.setPosition( position );
+
+		var result = svc.definition( params ).get();
+
+		assertThat( result ).isNotNull();
+		assertThat( result.isLeft() ).isTrue();
+		assertThat( result.getLeft() ).isNotEmpty();
+		assertThat( result.getLeft().getFirst().getUri() ).isEqualTo( mappedClass.toUri().toString() );
+	}
+
+	@Test
+	void testDefinitionReturnsMappedReferenceUriWhenServerCannotResolveMapping() throws Exception {
+		provider.setAppContext( new ProjectAppContext(
+		    workspaceRoot,
+		    Map.of(),
+		    List.of(),
+		    "no-server-mappings"
+		) );
+
+		Path	consumer	= workspaceRoot.resolve( "MappedFallbackConsumer.cfc" );
+		String	source		= """
+		                      component extends="testbox.system.BaseSpec" {
+		                      }
+		                      """;
+		Files.writeString( consumer, source );
+
+		BoxLangTextDocumentService svc = new BoxLangTextDocumentService();
+		svc.didOpen( new DidOpenTextDocumentParams(
+		    new TextDocumentItem( consumer.toUri().toString(), "boxlang", 1, source )
+		) );
+
+		int					tokenOffset	= source.indexOf( "extends" );
+		Position			position	= positionFromOffset( source, tokenOffset + 1 );
+
+		DefinitionParams	params		= new DefinitionParams();
+		params.setTextDocument( new TextDocumentIdentifier( consumer.toUri().toString() ) );
+		params.setPosition( position );
+
+		var result = svc.definition( params ).get();
+
+		assertThat( result ).isNotNull();
+		assertThat( result.isLeft() ).isTrue();
+		assertThat( result.getLeft() ).isNotEmpty();
+		assertThat( result.getLeft().getFirst().getUri() ).endsWith( "/testbox/system/BaseSpec" );
+	}
+
+	private boolean isInvalidExtendsDiagnostic( Diagnostic diagnostic ) {
+		if ( diagnostic.getCode() != null && diagnostic.getCode().isLeft() ) {
+			return InvalidExtendsRule.ID.equals( diagnostic.getCode().getLeft() );
+		}
+		return diagnostic.getMessage() != null && diagnostic.getMessage().contains( "extends reference" );
+	}
+
+	private boolean isInvalidImplementsDiagnostic( Diagnostic diagnostic ) {
+		if ( diagnostic.getCode() != null && diagnostic.getCode().isLeft() ) {
+			return InvalidImplementsRule.ID.equals( diagnostic.getCode().getLeft() );
+		}
+		return diagnostic.getMessage() != null && diagnostic.getMessage().contains( "implements reference" );
+	}
+
+	private Position positionFromOffset( String source, int offset ) {
+		int	line	= 0;
+		int	column	= 0;
+		for ( int i = 0; i < offset && i < source.length(); i++ ) {
+			if ( source.charAt( i ) == '\n' ) {
+				line++;
+				column = 0;
+			} else {
+				column++;
+			}
+		}
+		return new Position( line, column );
+	}
+}


### PR DESCRIPTION
## Summary
- add app-context parsing from initialize options (root, mappings, module dirs, hash)
- add mapping-aware class resolver shared by diagnostics and definition paths
- support mapped extends/implements/new/createObject references
- add tests for mapped resolution, app-context initialization, and definition behavior